### PR TITLE
fix: application_id naming

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -150,9 +150,7 @@ along with this program; if not, see
         return;
     }
 
-    let app = Application::builder()
-        .application_id("hyprwall")
-        .build();
+    let app = Application::builder().application_id("hyprwall").build();
 
     app.connect_activate(gui::build_ui);
     app.run();

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,7 @@ along with this program; if not, see
     }
 
     let app = Application::builder()
-        .application_id("nnyyxxxx.hyprwall")
+        .application_id("hyprwall")
         .build();
 
     app.connect_activate(gui::build_ui);


### PR DESCRIPTION
This fixes 'icon not shown' in applications that rely on proper application_id naming (e.g. nwg-dock-hyprland)