### PR TITLE
fix: switch gdk crate to gdk4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,39 +107,14 @@ checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cairo-rs"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
-dependencies = [
- "bitflags",
- "cairo-sys-rs 0.18.2",
- "glib 0.18.5",
- "libc",
- "once_cell",
- "thiserror",
-]
-
-[[package]]
-name = "cairo-rs"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a0ea147c94108c9613235388f540e4d14c327f7081c9e471fc8ee8a2533e69"
 dependencies = [
  "bitflags",
- "cairo-sys-rs 0.20.0",
+ "cairo-sys-rs",
  "glib 0.20.4",
  "libc",
-]
-
-[[package]]
-name = "cairo-sys-rs"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
-dependencies = [
- "glib-sys 0.18.1",
- "libc",
- "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -366,56 +341,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "gdk"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ba081bdef3b75ebcdbfc953699ed2d7417d6bd853347a42a37d76406a33646"
-dependencies = [
- "cairo-rs 0.18.5",
- "gdk-pixbuf 0.18.5",
- "gdk-sys",
- "gio 0.18.4",
- "glib 0.18.5",
- "libc",
- "pango 0.18.3",
-]
-
-[[package]]
-name = "gdk-pixbuf"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
-dependencies = [
- "gdk-pixbuf-sys 0.18.0",
- "gio 0.18.4",
- "glib 0.18.5",
- "libc",
- "once_cell",
-]
-
-[[package]]
 name = "gdk-pixbuf"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4c29071a9e92337d8270a85cb0510cda4ac478be26d09ad027cc1d081911b19"
 dependencies = [
- "gdk-pixbuf-sys 0.20.4",
- "gio 0.20.4",
+ "gdk-pixbuf-sys",
+ "gio",
  "glib 0.20.4",
  "libc",
-]
-
-[[package]]
-name = "gdk-pixbuf-sys"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
-dependencies = [
- "gio-sys 0.18.1",
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
- "libc",
- "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -432,35 +366,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "gdk-sys"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ff856cb3386dae1703a920f803abafcc580e9b5f711ca62ed1620c25b51ff2"
-dependencies = [
- "cairo-sys-rs 0.18.2",
- "gdk-pixbuf-sys 0.18.0",
- "gio-sys 0.18.1",
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
- "libc",
- "pango-sys 0.18.0",
- "pkg-config",
- "system-deps 6.2.2",
-]
-
-[[package]]
 name = "gdk4"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c121aeeb0cf7545877ae615dac6bfd088b739d8abee4d55e7143b06927d16a31"
+checksum = "d3fb4af2d606b0ac4e81f982f0d064bcb71ca73859ce5f30475f7eb2e2be4bc3"
 dependencies = [
- "cairo-rs 0.20.1",
- "gdk-pixbuf 0.20.4",
+ "cairo-rs",
+ "gdk-pixbuf",
  "gdk4-sys",
- "gio 0.20.4",
+ "gio",
  "glib 0.20.4",
  "libc",
- "pango 0.20.4",
+ "pango",
 ]
 
 [[package]]
@@ -469,13 +386,13 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d3c03d1ea9d5199f14f060890fde68a3b5ec5699144773d1fa6abf337bfbc9c"
 dependencies = [
- "cairo-sys-rs 0.20.0",
- "gdk-pixbuf-sys 0.20.4",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
  "gio-sys 0.20.4",
  "glib-sys 0.20.4",
  "gobject-sys 0.20.4",
  "libc",
- "pango-sys 0.20.4",
+ "pango-sys",
  "pkg-config",
  "system-deps 7.0.3",
 ]
@@ -496,25 +413,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "gio"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-util",
- "gio-sys 0.18.1",
- "glib 0.18.5",
- "libc",
- "once_cell",
- "pin-project-lite",
- "smallvec",
- "thiserror",
-]
 
 [[package]]
 name = "gio"
@@ -701,13 +599,13 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa21a2f7c51ee1c6cc1242c2faf3aae2b7566138f182696759987bde8219e922"
 dependencies = [
- "cairo-rs 0.20.1",
+ "cairo-rs",
  "gdk4",
  "glib 0.20.4",
  "graphene-rs",
  "gsk4-sys",
  "libc",
- "pango 0.20.4",
+ "pango",
 ]
 
 [[package]]
@@ -716,13 +614,13 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f9fb607554f9f4e8829eb7ea301b0fde051e1dbfd5d16b143a8a9c2fac6c01b"
 dependencies = [
- "cairo-sys-rs 0.20.0",
+ "cairo-sys-rs",
  "gdk4-sys",
  "glib-sys 0.20.4",
  "gobject-sys 0.20.4",
  "graphene-sys",
  "libc",
- "pango-sys 0.20.4",
+ "pango-sys",
  "system-deps 7.0.3",
 ]
 
@@ -732,19 +630,19 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e2d105ce672f5cdcb5af2602e91c2901e91c72da15ab76f613ad57ecf04c6d"
 dependencies = [
- "cairo-rs 0.20.1",
+ "cairo-rs",
  "field-offset",
  "futures-channel",
- "gdk-pixbuf 0.20.4",
+ "gdk-pixbuf",
  "gdk4",
- "gio 0.20.4",
+ "gio",
  "glib 0.20.4",
  "graphene-rs",
  "gsk4",
  "gtk4-macros",
  "gtk4-sys",
  "libc",
- "pango 0.20.4",
+ "pango",
 ]
 
 [[package]]
@@ -765,8 +663,8 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbe4325908b1c1642dbb48e9f49c07a73185babf43e8b2065b0f881a589f55b8"
 dependencies = [
- "cairo-sys-rs 0.20.0",
- "gdk-pixbuf-sys 0.20.4",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
  "gdk4-sys",
  "gio-sys 0.20.4",
  "glib-sys 0.20.4",
@@ -774,7 +672,7 @@ dependencies = [
  "graphene-sys",
  "gsk4-sys",
  "libc",
- "pango-sys 0.20.4",
+ "pango-sys",
  "system-deps 7.0.3",
 ]
 
@@ -808,8 +706,6 @@ version = "0.1.8"
 dependencies = [
  "clap",
  "crossbeam-channel",
- "gdk",
- "gio 0.18.4",
  "glib 0.18.5",
  "gtk4",
  "lazy_static",
@@ -938,39 +834,14 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pango"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
-dependencies = [
- "gio 0.18.4",
- "glib 0.18.5",
- "libc",
- "once_cell",
- "pango-sys 0.18.0",
-]
-
-[[package]]
-name = "pango"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa26aa54b11094d72141a754901cd71d9356432bb8147f9cace8d9c7ba95f356"
 dependencies = [
- "gio 0.20.4",
+ "gio",
  "glib 0.20.4",
  "libc",
- "pango-sys 0.20.4",
-]
-
-[[package]]
-name = "pango-sys"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
-dependencies = [
- "glib-sys 0.18.1",
- "gobject-sys 0.18.0",
- "libc",
- "system-deps 6.2.2",
+ "pango-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ edition = "2021"
 clap = { version = "4.3", features = ["derive"] }
 gtk = { version = "0.9.2", package = "gtk4" }
 glib = { version = "0.18.0", features = ["v2_68"] }
-gio = "0.18.0"
-gdk = "0.18.0"
 shellexpand = "3.1.0"
 lazy_static = "1.4.0"
 parking_lot = "0.12.1"


### PR DESCRIPTION
Helloo,

I wanted to package this project for nix and noticed that the built failed with:
```The system library `gdk-3.0` required by crate `gdk-sys` was not found.```

It seems like the rust crate gdk, which is for gdk 3 bindings https://crates.io/crates/gdk should instead be the gdk4 crate https://crates.io/crates/gdk4, so right now gtk3 would also be needed as a dependency

So the only thing I've done is 
```sh
cargo remove gdk
cargo add gdk4
```
and now hyprwall can be built with only gtk4 as a dependency!