### PR TITLE
fix: HashMap issues

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -13,7 +13,7 @@ use rand::seq::SliceRandom;
 use rayon::prelude::*;
 use std::{
     cell::RefCell,
-    collections::{HashMap, VecDeque},
+    collections::{BTreeMap, VecDeque},
     fs,
     io::{Read, Write},
     path::{Path, PathBuf},
@@ -28,7 +28,7 @@ const CONFIG_FILE: &str = "~/.config/hyprwall/config.ini";
 const CACHE_SIZE: usize = 100;
 
 struct ImageCache {
-    cache: HashMap<PathBuf, gdk::Texture>,
+    cache: BTreeMap<PathBuf, gdk::Texture>,
     order: VecDeque<PathBuf>,
 }
 
@@ -42,7 +42,7 @@ struct ImageLoader {
 impl ImageCache {
     fn new() -> Self {
         Self {
-            cache: HashMap::with_capacity(CACHE_SIZE),
+            cache: BTreeMap::new(),
             order: VecDeque::with_capacity(CACHE_SIZE),
         }
     }


### PR DESCRIPTION
it might be not a good idea to use HashMap here.
this replaces it with BTreeMap

HashMap issues:
- unpredictable order
- memory usage
- better for specific lookups, worse for range queries (not what we want)

all fixed here

BTreeMap advantages:
- sorted order (better UX)
- more efficient for range queries (searching, etc.)
- more predectable performance with bigger datasets
